### PR TITLE
offer a workaround for #608 ("Utils.getHTTPClient ignores trustAll parameter")

### DIFF
--- a/src/de/ub0r/android/websms/connector/common/Utils.java
+++ b/src/de/ub0r/android/websms/connector/common/Utils.java
@@ -706,6 +706,26 @@ public final class Utils {
 	}
 
 	/**
+	 * Shutdown and forget the cached HttpClient.
+	 *
+	 * This causes the client to be re-created with the used settings on the next
+	 * call to the getHttpClient()-family of functions.
+	 *
+	 * The caller has to use this method before calling a getHttpClient() with new
+	 * trustAll or fingerprints.
+	 *
+	 * Calling this function while no cached Client exits does nothing.
+	 */
+	public static void resetHttpClient() {
+		if (httpClient == null) {
+			return;
+		}
+
+		httpClient.getConnectionManager().shutdown();
+		httpClient = null;
+	}
+
+	/**
 	 * Read {@link InputStream} and convert it into {@link String}.
 	 * 
 	 * @param is


### PR DESCRIPTION
This is more of a workaround for issue [#608](http://code.google.com/p/websmsdroid/issues/detail?id=608) which prevents the trustAll-parameter from getting used in certain situations. The underlying problem is that the httpClient is cached by Utils.getHttpClient after its created for the first time. So as long as websms runs in the background as a cached process, any change of the trustAll-parameter in the settings are ignore because no new httpClient is created after that.

As the caching is a good thing and even seems to be used for some cookie-handling, I did not change this behaviour but added a resetHttpClient() which can be called by a connector after a significant settings-change.

However I don't think this is a very nice way of handling with this because the connectors need to be aware of this when using the websms-api...
