### PR TITLE
bug fixes

### DIFF
--- a/src/de/ub0r/android/websms/connector/common/ConnectorService.java
+++ b/src/de/ub0r/android/websms/connector/common/ConnectorService.java
@@ -82,11 +82,13 @@ public final class ConnectorService extends IntentService {
 	 */
 	@Override
 	public void onStart(final Intent intent, final int startId) {
-		super.onStart(intent, startId);
 		Log.d(TAG, "onStart()");
 		if (intent != null) {
 			this.register(intent);
 		}
+		// note that super.onStart will start processing the intent on the
+		// background thread so we need to register etc before that
+		super.onStart(intent, startId);
 	}
 
 	/**


### PR DESCRIPTION
87a33ee54f: I've noticed that, if I use AutoUpdate and AutoSend together and Send arrives into the connector quickly after Update, then the Sending notification never goes away. Apparently, there was a broken intent comparison in "unregister" so updates are never removed from pendingIOOps.

646104f9a9: While debugging the previous one, I've noticed that "register" is sometimes called _after_ the service has already started processing the intent. Fixed the threading issue.
